### PR TITLE
Provide pthread_cond_timedwait_w32() for Windows Vista+ too.

### DIFF
--- a/compat/w32pthreads.h
+++ b/compat/w32pthreads.h
@@ -143,6 +143,12 @@ static inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex
     return 0;
 }
 
+static inline int pthread_cond_timedwait_w32(pthread_cond_t *cond, pthread_mutex_t *mutex, DWORD timeout)
+{
+    SleepConditionVariableCS(cond, mutex, timeout);
+    return 0;
+}
+
 static inline void pthread_cond_signal(pthread_cond_t *cond)
 {
     WakeConditionVariable(cond);


### PR DESCRIPTION
If the target system is Windows Vista or later, native Windows synchronization is being used inside pthreads but there is no pthread_cond_timedwait_w32() function available.

Providing the function allows MPC-HC to be built when Vista or a later version of the OS is targeted.
